### PR TITLE
delay activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "categories": [
         "Programming Languages"
     ],
-    "activationEvents": [
-        "onStartupFinished"
-    ],
     "icon": "KDL_Logo_Only_128x128.png",
     "contributes": {
         "languages": [


### PR DESCRIPTION
This PR changes `activationEvents` from `onStartupFinished` to `onLanguage:kdl`. And starting from VSCode 1.74, `onLanguage` events will be generated automatically. So we can simply leave it blank.

Reference: [code.visualstudio.com/api/references/activation-events#onLanguage](https://code.visualstudio.com/api/references/activation-events#onLanguage)